### PR TITLE
Allow more exotic author names

### DIFF
--- a/server.js
+++ b/server.js
@@ -220,11 +220,9 @@ function fetchComments() {
                 in_reply_to = []
                 
                 //See if there any explicit @ references
-                //Currently, we count anything from an @ to a non-alphanumeric, non-space 
-                //character as the author name.  (This is because usually they'll be a 
-                //comma or a <p> at the end of the name).
-                //We trim whitespace
-                var regex = /@([a-zA-Z0-9\. ]+)/g
+                //Currently, we count anything from an @ to a '@', '.', ';', ':', ',', or dash
+                //as an author name.
+                var regex = /@([^@.;:,\-\u2013\u2014]+)/g
                 while (match = regex.exec(comment.content.rendered)) {
                     in_reply_to.push(match[1].trim());
                     

--- a/server.js
+++ b/server.js
@@ -220,9 +220,9 @@ function fetchComments() {
                 in_reply_to = []
                 
                 //See if there any explicit @ references
-                //Currently, we count anything from an @ to a '@', '.', ';', ':', ',', or dash
+                //Currently, we count anything from an @ to a '@', '<', '.', ';', ':', ',', or dash
                 //as an author name.
-                var regex = /@([^@.;:,\-\u2013\u2014]+)/g
+                var regex = /@([^@<.;:,\-\u2013\u2014]+)/g
                 while (match = regex.exec(comment.content.rendered)) {
                     in_reply_to.push(match[1].trim());
                     


### PR DESCRIPTION
In practice people sometimes have [weird characters](http://slatestarcodex.com/2017/06/04/ot77-opium-thread/#comment-507135) in their handles; this is a little more permissive.

This still won't catch people who put [dashes in their names](http://slatestarcodex.com/2017/06/04/ot77-opium-thread/#comment-507754). Maybe something can be done about that eventually, but I'm not sure what it'd look like.